### PR TITLE
1.0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "php": ">=5.4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": ">5.7"
+    "phpunit/phpunit": "5.7.*|7.4.*"
   },
   "license": "MIT"
 }

--- a/src/FromUTF8.php
+++ b/src/FromUTF8.php
@@ -75,6 +75,13 @@ class FromUTF8
         }
     }
 
+    /**
+     * RFC 2047
+     *
+     * @param $text
+     * @param int $breakColumn
+     * @return string
+     */
     public static function toMimeEncodedWord($text, $breakColumn = 0)
     {
 //        // Fix break into the middle of the UTF8 char

--- a/src/FromUTF8.php
+++ b/src/FromUTF8.php
@@ -8,6 +8,7 @@ class FromUTF8
     /**
      * Convert a text in UTF8 to ISO-8859-1 used in emails.
      *
+     * @deprecated Use instead: toMimeEncodedWord
      * @param string $text
      * @param int $wrap
      * @return string
@@ -72,6 +73,35 @@ class FromUTF8
             $newResult .= "?=";
             return $newResult;
         }
+    }
+
+    public static function toMimeEncodedWord($text, $breakColumn = 0)
+    {
+//        // Fix break into the middle of the UTF8 char
+//        if ($breakColumn > 0) {
+//            $result = "";
+//            while (!empty($text)) {
+//                $result .= FromUTF8::toMimeEncodedWord(substr($text, 0, $breakColumn)) . "\n";
+//                $text = substr($text, $breakColumn);
+//            }
+//            return $result;
+//        }
+
+        $result = "";
+        for ($i = 0; $i < strlen($text); $i++) {
+            $decimal = ord($text[$i]);
+            if ($decimal > 127 || $decimal == 63) {
+                $result .= "=" . strtoupper(dechex($decimal));
+                continue;
+            }
+            $result .= $text[$i];
+        }
+
+        if ($result == $text) {
+            return $text;
+        }
+
+        return "=?utf-8?Q?" . str_replace(" ", "_", $result) . "?=";
     }
 
     /**

--- a/src/FromUTF8.php
+++ b/src/FromUTF8.php
@@ -77,23 +77,13 @@ class FromUTF8
 
     /**
      * RFC 2047
+     * https://sjohannes.wordpress.com/2009/05/18/utf-8-explained/
      *
      * @param $text
-     * @param int $breakColumn
      * @return string
      */
-    public static function toMimeEncodedWord($text, $breakColumn = 0)
+    public static function toMimeEncodedWord($text)
     {
-//        // Fix break into the middle of the UTF8 char
-//        if ($breakColumn > 0) {
-//            $result = "";
-//            while (!empty($text)) {
-//                $result .= FromUTF8::toMimeEncodedWord(substr($text, 0, $breakColumn)) . "\n";
-//                $text = substr($text, $breakColumn);
-//            }
-//            return $result;
-//        }
-
         $result = "";
         for ($i = 0; $i < strlen($text); $i++) {
             $decimal = ord($text[$i]);

--- a/tests/src/FromUTF8Test.php
+++ b/tests/src/FromUTF8Test.php
@@ -72,11 +72,6 @@ class FromUTF8Test extends TestCase
             "=?utf-8?Q?=D0=AF=D0=BA_=D1=82=D0=B8_=D0=BF=D0=BE=D0=B6=D0=B8=D0=B2=D0=B0=D1=94=D1=88=3F?=",
             FromUTF8::toMimeEncodedWord(base64_decode("0K/QuiDRgtC4INC/0L7QttC40LLQsNGU0Yg/?="))
         );
-
-//        $this->assertEquals(
-//            "=?utf-8?Q?=D0=AF=D0=BA_=D1=82=D0=B8_=D0=BF=D0=BE=D0=B6=D0=B8=D0=B2=D0=B0=D1=94=D1=88=3F?=",
-//            FromUTF8::toMimeEncodedWord(base64_decode("0K/QuiDRgtC4INC/0L7QttC40LLQsNGU0Yg/?="), 5)
-//        );
     }
 
     public function testRemoveAccent()

--- a/tests/src/FromUTF8Test.php
+++ b/tests/src/FromUTF8Test.php
@@ -51,6 +51,34 @@ class FromUTF8Test extends TestCase
         );
     }
 
+    public function testToMimeEncodedWord()
+    {
+        $this->assertEquals(
+            "=?utf-8?Q?Libert=C3=A9_Egalit=C3=A9_Fraternit=C3=A9?=",
+            FromUTF8::toMimeEncodedWord("Liberté Egalité Fraternité")
+        );
+
+        $this->assertEquals(
+            "=?utf-8?Q?=C3=A1=C3=A9=C3=AD=C3=B3=C3=BA?=",
+            FromUTF8::toMimeEncodedWord("áéíóú")
+        );
+
+        $this->assertEquals(
+            "=?utf-8?Q?Test_=C5=A9=C5=A8?=",
+            FromUTF8::toMimeEncodedWord("Test ũŨ")
+        );
+
+        $this->assertEquals(
+            "=?utf-8?Q?=D0=AF=D0=BA_=D1=82=D0=B8_=D0=BF=D0=BE=D0=B6=D0=B8=D0=B2=D0=B0=D1=94=D1=88=3F?=",
+            FromUTF8::toMimeEncodedWord(base64_decode("0K/QuiDRgtC4INC/0L7QttC40LLQsNGU0Yg/?="))
+        );
+
+//        $this->assertEquals(
+//            "=?utf-8?Q?=D0=AF=D0=BA_=D1=82=D0=B8_=D0=BF=D0=BE=D0=B6=D0=B8=D0=B2=D0=B0=D1=94=D1=88=3F?=",
+//            FromUTF8::toMimeEncodedWord(base64_decode("0K/QuiDRgtC4INC/0L7QttC40LLQsNGU0Yg/?="), 5)
+//        );
+    }
+
     public function testRemoveAccent()
     {
         $this->assertEquals(


### PR DESCRIPTION
deprecate `FromUTF8::toIso88591Email()` in favor of `FromUTF8::toMimeEncodedWord()`
